### PR TITLE
Documentation clean up

### DIFF
--- a/mecha.zig
+++ b/mecha.zig
@@ -100,7 +100,7 @@ test "string" {
 }
 
 /// Construct a parser that repeatedly uses `parser` until `n` iterations is reached.
-/// The parsers result will be an array of the results from the repeated parser.
+/// The parser's result will be an array of the results from the repeated parser.
 pub fn manyN(
     comptime n: usize,
     comptime parser: anytype,
@@ -124,7 +124,7 @@ pub fn manyN(
 
 /// Construct a parser that repeatedly uses `parser` until it fails
 /// or `m` iterations is reached. The parser constructed will only
-/// succeed if `parser` succeeded at least `n` times. The parsers
+/// succeed if `parser` succeeded at least `n` times. The parser's
 /// result will be a string containing everything parsed.
 pub fn manyRange(
     comptime n: usize,
@@ -149,7 +149,7 @@ pub fn manyRange(
 }
 
 /// Construct a parser that repeatedly uses `parser` until it fails.
-/// The parsers result will be a string containing everything parsed.
+/// The parser's result will be a string containing everything parsed.
 pub fn many(comptime parser: anytype) Parser([]const u8) {
     return manyRange(0, math.maxInt(usize), parser);
 }
@@ -181,7 +181,7 @@ test "many" {
 }
 
 /// Construct a parser that will call `parser` on the string
-/// but never fails to parser. The parsers result will be the
+/// but never fails to parse. The parser's result will be the
 /// result of `parser` on success and `null` on failure.
 pub fn opt(comptime parser: anytype) Parser(?ParserResult(@TypeOf(parser))) {
     return struct {
@@ -463,7 +463,7 @@ fn ToStructResult(comptime T: type) type {
     }.func);
 }
 
-/// Constructs a convert function for `as` that takes a tuple or an array and
+/// Constructs a convert function for `map` that takes a tuple or an array and
 /// converts it into the struct `T`. Fields will be assigned in order,
 /// so `tuple[i]` will be assigned to the ith field of `T`. This function
 /// will give a compile error if `T` and the tuple does not have the same
@@ -475,7 +475,7 @@ pub fn toStruct(comptime T: type) ToStructResult(T) {
             const struct_fields = @typeInfo(T).Struct.fields;
             if (struct_fields.len != tuple.len)
                 @compileError(@typeName(T) ++ " and " ++ @typeName(@TypeOf(tuple)) ++ " does not have " ++
-                    "same number of fields. Convertion is not possible.");
+                    "same number of fields. Conversion is not possible.");
 
             var res: T = undefined;
             inline for (struct_fields) |field, i|
@@ -503,7 +503,7 @@ test "map" {
 }
 
 /// Constructs a parser that discards the result returned from the parser
-/// it warps.
+/// it wraps.
 pub fn discard(comptime parser: anytype) Parser(void) {
     return convert(void, struct {
         fn d(_: anytype) ?void {}
@@ -551,7 +551,7 @@ test "int" {
     expectResult(u8, null, parser2("100"));
 }
 
-/// Creates a parser that calls a function to optain its underlying parser.
+/// Creates a parser that calls a function to obtain its underlying parser.
 /// This function introduces the indirection required for recursive grammars.
 /// ```
 /// const digit_10 = discard(digit(10));

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -49,7 +49,7 @@ test "range" {
 
 /// A parser that succeeds if the string starts with an upper case
 /// character. The parser's result will be the character parsed.
-pub const upper = mecha.oneOf(.{range('A', 'Z')});
+pub const upper = range('A', 'Z');
 
 test "upper" {
     var i: u8 = 0;

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -20,7 +20,7 @@ test "char" {
 
 /// Constructs a parser that only succeeds if the string starts with
 /// a codepoint that is in between `start` and `end` inclusively.
-/// The parsers result will be the codepoint parsed.
+/// The parser's result will be the codepoint parsed.
 pub fn range(comptime start: u8, comptime end: u8) mecha.Parser(u8) {
     return struct {
         const Res = mecha.Result(u8);
@@ -48,7 +48,7 @@ test "range" {
 }
 
 /// A parser that succeeds if the string starts with an upper case
-/// character. The parsers result will be the character parsed.
+/// character. The parser's result will be the character parsed.
 pub const upper = mecha.oneOf(.{range('A', 'Z')});
 
 test "upper" {
@@ -61,9 +61,9 @@ test "upper" {
     }
 }
 
-/// A parser that succeeds if the string starts with an upper case
-/// character. The parsers result will be the character parsed.
-pub const lower = mecha.oneOf(.{range('a', 'z')});
+/// A parser that succeeds if the string starts with a lower case
+/// character. The parser's result will be the character parsed.
+pub const lower = range('a', 'z');
 
 test "lower" {
     var i: u8 = 0;
@@ -76,7 +76,7 @@ test "lower" {
 }
 
 /// A parser that succeeds if the string starts with an alphabetic
-/// character. The parsers result will be the character parsed.
+/// character. The parser's result will be the character parsed.
 pub const alpha = mecha.oneOf(.{ lower, upper });
 
 test "alpha" {
@@ -92,7 +92,7 @@ test "alpha" {
 }
 
 /// Construct a parser that succeeds if the string starts with a
-/// character that is a digit in `base`. The parsers result will be
+/// character that is a digit in `base`. The parser's result will be
 /// the character parsed.
 pub fn digit(comptime base: u8) mecha.Parser(u8) {
     debug.assert(base != 0);
@@ -134,8 +134,8 @@ test "digit" {
     }
 }
 
-/// A parser that succeeds if the string starts with an alphabetic
-/// or numeric character. The parsers result will be the character parsed.
+/// A parser that succeeds if the string starts with an alphabetic or
+/// numeric character. The parser's result will be the character parsed.
 pub const alphanum = mecha.oneOf(.{ alpha, digit(10) });
 
 test "alphanum" {

--- a/src/utf8.zig
+++ b/src/utf8.zig
@@ -4,7 +4,7 @@ const mecha = @import("../mecha.zig");
 const math = std.math;
 const unicode = std.unicode;
 
-// Constructs a parser that only succeeds if the string starts with `c`.
+/// Constructs a parser that only succeeds if the string starts with `c`.
 pub fn char(comptime c: u21) mecha.Parser(void) {
     comptime {
         var array: [4]u8 = undefined;
@@ -25,7 +25,7 @@ test "char" {
 
 /// Constructs a parser that only succeeds if the string starts with
 /// a codepoint that is in between `start` and `end` inclusively.
-/// The parsers result will be the codepoint parsed.
+/// The parser's result will be the codepoint parsed.
 pub fn range(comptime start: u21, comptime end: u21) mecha.Parser(u21) {
     return struct {
         const Res = mecha.Result(u21);


### PR DESCRIPTION
There were some typos and references to functions which have since been renamed in the doc comments.

There was also what seemed to be an unneeded call to `mecha.oneOf` in the ascii module. I removed those and tests still passed, but maybe I'm missing some reason why those are desirable to have. 