### PR TITLE
Allow Allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ const rgb = combine(.{
 });
 
 test "rgb" {
-    const a = (try rgb("#aabbcc")).value;
+    var allocator = std.testing.allocator;
+    const a = (try rgb(allocator, "#aabbcc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), a.r);
     std.testing.expectEqual(@as(u8, 0xbb), a.g);
     std.testing.expectEqual(@as(u8, 0xcc), a.b);
 
-    const b = (try rgb("#abc")).value;
+    const b = (try rgb(allocator, "#abc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), b.r);
     std.testing.expectEqual(@as(u8, 0xbb), b.g);
     std.testing.expectEqual(@as(u8, 0xcc), b.b);

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ const rgb = combine(.{
 });
 
 test "rgb" {
-    var allocator = std.testing.allocator;
+    const allocator = std.testing.allocator;
     const a = (try rgb(allocator, "#aabbcc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), a.r);
     std.testing.expectEqual(@as(u8, 0xbb), a.g);

--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ const rgb = combine(.{
 });
 
 test "rgb" {
-    const a = rgb("#aabbcc").?.value;
+    const a = (try rgb("#aabbcc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), a.r);
     std.testing.expectEqual(@as(u8, 0xbb), a.g);
     std.testing.expectEqual(@as(u8, 0xcc), a.b);
 
-    const b = rgb("#abc").?.value;
+    const b = (try rgb("#abc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), b.r);
     std.testing.expectEqual(@as(u8, 0xbb), b.g);
     std.testing.expectEqual(@as(u8, 0xcc), b.b);

--- a/example/json.zig
+++ b/example/json.zig
@@ -115,23 +115,21 @@ const ws = discard(many(oneOf(.{
 })));
 
 fn ok(comptime s: []const u8) void {
-    const res = json(s);
-    testing.expect(res != null);
-    testing.expectEqualStrings("", res.?.rest);
+    const res = json(s) catch @panic("test failure");
+    testing.expectEqualStrings("", res.rest);
 }
 
 fn err(comptime s: []const u8) void {
-    testing.expect(json(s) == null);
+    testing.expectError(error.ParserFailed, json(s));
 }
 
 fn errNotAllParsed(comptime s: []const u8) void {
-    const res = json(s);
-    testing.expect(res != null);
-    testing.expect(res.?.rest.len != 0);
+    const res = json(s) catch @panic("test failure");
+    testing.expect(res.rest.len != 0);
 }
 
 fn any(comptime s: []const u8) void {
-    _ = json(s);
+    _ = json(s) catch {};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/example/json.zig
+++ b/example/json.zig
@@ -115,21 +115,21 @@ const ws = discard(many(oneOf(.{
 })));
 
 fn ok(comptime s: []const u8) void {
-    const res = json(s) catch @panic("test failure");
+    const res = json(testing.allocator, s) catch @panic("test failure");
     testing.expectEqualStrings("", res.rest);
 }
 
 fn err(comptime s: []const u8) void {
-    testing.expectError(error.ParserFailed, json(s));
+    testing.expectError(error.ParserFailed, json(testing.allocator, s));
 }
 
 fn errNotAllParsed(comptime s: []const u8) void {
-    const res = json(s) catch @panic("test failure");
+    const res = json(testing.allocator, s) catch @panic("test failure");
     testing.expect(res.rest.len != 0);
 }
 
 fn any(comptime s: []const u8) void {
-    _ = json(s) catch {};
+    _ = json(testing.allocator, s) catch {};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/example/rgb.zig
+++ b/example/rgb.zig
@@ -30,7 +30,7 @@ const rgb = combine(.{
 });
 
 test "rgb" {
-    var allocator = std.testing.allocator;
+    const allocator = std.testing.allocator;
     const a = (try rgb(allocator, "#aabbcc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), a.r);
     std.testing.expectEqual(@as(u8, 0xbb), a.g);

--- a/example/rgb.zig
+++ b/example/rgb.zig
@@ -30,12 +30,12 @@ const rgb = combine(.{
 });
 
 test "rgb" {
-    const a = rgb("#aabbcc").?.value;
+    const a = (try rgb("#aabbcc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), a.r);
     std.testing.expectEqual(@as(u8, 0xbb), a.g);
     std.testing.expectEqual(@as(u8, 0xcc), a.b);
 
-    const b = rgb("#abc").?.value;
+    const b = (try rgb("#abc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), b.r);
     std.testing.expectEqual(@as(u8, 0xbb), b.g);
     std.testing.expectEqual(@as(u8, 0xcc), b.b);

--- a/example/rgb.zig
+++ b/example/rgb.zig
@@ -30,12 +30,13 @@ const rgb = combine(.{
 });
 
 test "rgb" {
-    const a = (try rgb("#aabbcc")).value;
+    var allocator = std.testing.allocator;
+    const a = (try rgb(allocator, "#aabbcc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), a.r);
     std.testing.expectEqual(@as(u8, 0xbb), a.g);
     std.testing.expectEqual(@as(u8, 0xcc), a.b);
 
-    const b = (try rgb("#abc")).value;
+    const b = (try rgb(allocator, "#abc")).value;
     std.testing.expectEqual(@as(u8, 0xaa), b.r);
     std.testing.expectEqual(@as(u8, 0xbb), b.g);
     std.testing.expectEqual(@as(u8, 0xcc), b.b);

--- a/mecha.zig
+++ b/mecha.zig
@@ -69,7 +69,7 @@ pub fn eos(_: *mem.Allocator, str: []const u8) Error!Result(void) {
 }
 
 test "eos" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     expectResult(void, .{ .value = {}, .rest = "" }, eos(allocator, ""));
     expectResult(void, error.ParserFailed, eos(allocator, "a"));
 }
@@ -81,7 +81,7 @@ pub fn rest(_: *mem.Allocator, str: []const u8) Error!Result([]const u8) {
 }
 
 test "rest" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     expectResult([]const u8, .{ .value = "", .rest = "" }, rest(allocator, ""));
     expectResult([]const u8, .{ .value = "a", .rest = "" }, rest(allocator, "a"));
 }
@@ -100,7 +100,7 @@ pub fn string(comptime str: []const u8) Parser(void) {
 }
 
 test "string" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     expectResult(void, .{ .value = {}, .rest = "" }, string("aa")(allocator, "aa"));
     expectResult(void, .{ .value = {}, .rest = "a" }, string("aa")(allocator, "aaa"));
     expectResult(void, error.ParserFailed, string("aa")(allocator, "ba"));
@@ -166,7 +166,7 @@ pub fn many(comptime parser: anytype) Parser([]const u8) {
 }
 
 test "many" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser1 = comptime many(string("ab"));
     expectResult([]const u8, .{ .value = "", .rest = "" }, parser1(allocator, ""));
     expectResult([]const u8, .{ .value = "", .rest = "a" }, parser1(allocator, "a"));
@@ -209,7 +209,7 @@ pub fn opt(comptime parser: anytype) Parser(?ParserResult(@TypeOf(parser))) {
 }
 
 test "opt" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser1 = comptime opt(ascii.range('a', 'z'));
     expectResult(?u8, .{ .value = 'a', .rest = "" }, parser1(allocator, "a"));
     expectResult(?u8, .{ .value = 'a', .rest = "a" }, parser1(allocator, "aa"));
@@ -277,7 +277,7 @@ pub fn combine(comptime parsers: anytype) Parser(Combine(parsers)) {
 }
 
 test "combine" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser1 = comptime combine(.{ opt(ascii.range('a', 'b')), opt(ascii.range('d', 'e')) });
     const Res = ParserResult(@TypeOf(parser1));
     expectResult(Res, .{ .value = .{ .@"0" = 'a', .@"1" = 'd' }, .rest = "" }, parser1(allocator, "ad"));
@@ -319,7 +319,7 @@ pub fn oneOf(comptime parsers: anytype) Parser(ParserResult(@TypeOf(parsers[0]))
 }
 
 test "oneOf" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser1 = comptime oneOf(.{ ascii.range('a', 'b'), ascii.range('d', 'e') });
     expectResult(u8, .{ .value = 'a', .rest = "" }, parser1(allocator, "a"));
     expectResult(u8, .{ .value = 'b', .rest = "" }, parser1(allocator, "b"));
@@ -347,7 +347,7 @@ pub fn asStr(comptime parser: anytype) Parser([]const u8) {
 }
 
 test "asStr" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser1 = comptime asStr(ascii.char('a'));
     expectResult([]const u8, .{ .value = "a", .rest = "" }, parser1(allocator, "a"));
     expectResult([]const u8, .{ .value = "a", .rest = "a" }, parser1(allocator, "aa"));
@@ -434,7 +434,7 @@ pub fn toBool(allocator: *mem.Allocator, str: []const u8) Error!bool {
 }
 
 test "convert" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser1 = comptime convert(u8, toInt(u8, 10), asStr(string("123")));
     expectResult(u8, .{ .value = 123, .rest = "" }, parser1(allocator, "123"));
     expectResult(u8, .{ .value = 123, .rest = "a" }, parser1(allocator, "123a"));
@@ -516,7 +516,7 @@ pub fn toStruct(comptime T: type) ToStructResult(T) {
 }
 
 test "map" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const Point = struct {
         x: usize,
         y: usize,
@@ -541,7 +541,7 @@ pub fn discard(comptime parser: anytype) Parser(void) {
 }
 
 test "discard" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser = comptime discard(many(ascii.char(' ')));
     expectResult(void, .{ .value = {}, .rest = "abc" }, parser(allocator, "abc"));
     expectResult(void, .{ .value = {}, .rest = "abc" }, parser(allocator, " abc"));
@@ -565,7 +565,7 @@ pub fn int(comptime Int: type, comptime base: u8) Parser(Int) {
 }
 
 test "int" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const parser1 = int(u8, 10);
     expectResult(u8, .{ .value = 0, .rest = "" }, parser1(allocator, "0"));
     expectResult(u8, .{ .value = 1, .rest = "" }, parser1(allocator, "1"));

--- a/mecha.zig
+++ b/mecha.zig
@@ -4,8 +4,8 @@ const debug = std.debug;
 const fmt = std.fmt;
 const math = std.math;
 const mem = std.mem;
-const unicode = std.unicode;
 const testing = std.testing;
+const unicode = std.unicode;
 
 pub const ascii = @import("src/ascii.zig");
 pub const utf8 = @import("src/utf8.zig");
@@ -69,7 +69,7 @@ pub fn eos(_: *mem.Allocator, str: []const u8) Error!Result(void) {
 }
 
 test "eos" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     expectResult(void, .{ .value = {}, .rest = "" }, eos(allocator, ""));
     expectResult(void, error.ParserFailed, eos(allocator, "a"));
 }
@@ -81,7 +81,7 @@ pub fn rest(_: *mem.Allocator, str: []const u8) Error!Result([]const u8) {
 }
 
 test "rest" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     expectResult([]const u8, .{ .value = "", .rest = "" }, rest(allocator, ""));
     expectResult([]const u8, .{ .value = "a", .rest = "" }, rest(allocator, "a"));
 }
@@ -100,7 +100,7 @@ pub fn string(comptime str: []const u8) Parser(void) {
 }
 
 test "string" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     expectResult(void, .{ .value = {}, .rest = "" }, string("aa")(allocator, "aa"));
     expectResult(void, .{ .value = {}, .rest = "a" }, string("aa")(allocator, "aaa"));
     expectResult(void, error.ParserFailed, string("aa")(allocator, "ba"));
@@ -166,7 +166,7 @@ pub fn many(comptime parser: anytype) Parser([]const u8) {
 }
 
 test "many" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser1 = comptime many(string("ab"));
     expectResult([]const u8, .{ .value = "", .rest = "" }, parser1(allocator, ""));
     expectResult([]const u8, .{ .value = "", .rest = "a" }, parser1(allocator, "a"));
@@ -209,7 +209,7 @@ pub fn opt(comptime parser: anytype) Parser(?ParserResult(@TypeOf(parser))) {
 }
 
 test "opt" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser1 = comptime opt(ascii.range('a', 'z'));
     expectResult(?u8, .{ .value = 'a', .rest = "" }, parser1(allocator, "a"));
     expectResult(?u8, .{ .value = 'a', .rest = "a" }, parser1(allocator, "aa"));
@@ -277,7 +277,7 @@ pub fn combine(comptime parsers: anytype) Parser(Combine(parsers)) {
 }
 
 test "combine" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser1 = comptime combine(.{ opt(ascii.range('a', 'b')), opt(ascii.range('d', 'e')) });
     const Res = ParserResult(@TypeOf(parser1));
     expectResult(Res, .{ .value = .{ .@"0" = 'a', .@"1" = 'd' }, .rest = "" }, parser1(allocator, "ad"));
@@ -319,7 +319,7 @@ pub fn oneOf(comptime parsers: anytype) Parser(ParserResult(@TypeOf(parsers[0]))
 }
 
 test "oneOf" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser1 = comptime oneOf(.{ ascii.range('a', 'b'), ascii.range('d', 'e') });
     expectResult(u8, .{ .value = 'a', .rest = "" }, parser1(allocator, "a"));
     expectResult(u8, .{ .value = 'b', .rest = "" }, parser1(allocator, "b"));
@@ -347,7 +347,7 @@ pub fn asStr(comptime parser: anytype) Parser([]const u8) {
 }
 
 test "asStr" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser1 = comptime asStr(ascii.char('a'));
     expectResult([]const u8, .{ .value = "a", .rest = "" }, parser1(allocator, "a"));
     expectResult([]const u8, .{ .value = "a", .rest = "a" }, parser1(allocator, "aa"));
@@ -434,7 +434,7 @@ pub fn toBool(allocator: *mem.Allocator, str: []const u8) Error!bool {
 }
 
 test "convert" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser1 = comptime convert(u8, toInt(u8, 10), asStr(string("123")));
     expectResult(u8, .{ .value = 123, .rest = "" }, parser1(allocator, "123"));
     expectResult(u8, .{ .value = 123, .rest = "a" }, parser1(allocator, "123a"));
@@ -516,7 +516,7 @@ pub fn toStruct(comptime T: type) ToStructResult(T) {
 }
 
 test "map" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const Point = struct {
         x: usize,
         y: usize,
@@ -541,7 +541,7 @@ pub fn discard(comptime parser: anytype) Parser(void) {
 }
 
 test "discard" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser = comptime discard(many(ascii.char(' ')));
     expectResult(void, .{ .value = {}, .rest = "abc" }, parser(allocator, "abc"));
     expectResult(void, .{ .value = {}, .rest = "abc" }, parser(allocator, " abc"));
@@ -565,7 +565,7 @@ pub fn int(comptime Int: type, comptime base: u8) Parser(Int) {
 }
 
 test "int" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const parser1 = int(u8, 10);
     expectResult(u8, .{ .value = 0, .rest = "" }, parser1(allocator, "0"));
     expectResult(u8, .{ .value = 1, .rest = "" }, parser1(allocator, "1"));
@@ -603,7 +603,7 @@ pub fn ref(comptime func: anytype) Parser(ParserResult(ReturnType(@TypeOf(func))
 }
 
 test "ref" {
-    const allocator = &failingAllocator();
+    const allocator = testing.failing_allocator;
     const Scope = struct {
         const digit = discard(ascii.digit(10));
         const digits = oneOf(.{ combine(.{ digit, ref(digits_ref) }), digit });
@@ -631,8 +631,4 @@ pub fn expectResult(
         []const u8 => testing.expectEqualStrings(expect.value, actual.value),
         else => testing.expectEqual(expect.value, actual.value),
     }
-}
-
-fn failingAllocator() mem.Allocator {
-    return testing.FailingAllocator.init(testing.allocator, 0).allocator;
 }

--- a/mecha.zig
+++ b/mecha.zig
@@ -148,11 +148,9 @@ pub fn manyRange(
 
             var i: usize = n;
             while (i < m) : (i += 1) {
-                const r = parser(allocator, rem) catch |e| {
-                    switch (e) {
-                        error.ParserFailed => break,
-                        else => return e,
-                    }
+                const r = parser(allocator, rem) catch |e| switch (e) {
+                    error.ParserFailed => break,
+                    else => return e,
                 };
                 rem = r.rest;
             }
@@ -201,11 +199,9 @@ pub fn opt(comptime parser: anytype) Parser(?ParserResult(@TypeOf(parser))) {
     return struct {
         const Res = Result(?ParserResult(@TypeOf(parser)));
         fn func(allocator: *mem.Allocator, str: []const u8) Error!Res {
-            const r = parser(allocator, str) catch |e| {
-                switch (e) {
-                    error.ParserFailed => return Res.init(null, str),
-                    else => return e,
-                }
+            const r = parser(allocator, str) catch |e| switch (e) {
+                error.ParserFailed => return Res.init(null, str),
+                else => return e,
             };
             return Res.init(r.value, r.rest);
         }
@@ -377,12 +373,10 @@ pub fn convert(
         const Res = Result(T);
         fn func(allocator: *mem.Allocator, str: []const u8) Error!Res {
             const r = try parser(allocator, str);
-            const v = conv(allocator, r.value) catch |e| {
-                switch (@as(anyerror, e)) {
-                    error.ParserFailed => return error.ParserFailed,
-                    error.OutOfMemory => return error.OutOfMemory,
-                    else => return error.OtherError,
-                }
+            const v = conv(allocator, r.value) catch |e| switch (@as(anyerror, e)) {
+                error.ParserFailed => return error.ParserFailed,
+                error.OutOfMemory => return error.OutOfMemory,
+                else => return error.OtherError,
             };
             return Res.init(v, r.rest);
         }

--- a/mecha.zig
+++ b/mecha.zig
@@ -410,7 +410,7 @@ pub fn toChar(_: *mem.Allocator, str: []const u8) anyerror!u21 {
         const cp_len = try unicode.utf8ByteSequenceLength(str[0]);
         if (cp_len > str.len)
             return error.ParserFailed;
-        return unicode.utf8Decode(str[0..cp_len]);
+        return unicode.utf8Decode(str[0..cp_len]) catch error.ParserFailed;
     }
     return @as(u21, str[0]);
 }

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -5,7 +5,7 @@ const debug = std.debug;
 const math = std.math;
 const mem = std.mem;
 const testing = std.testing;
-///
+
 /// Constructs a parser that only succeeds if the string starts with `i`.
 pub fn char(comptime i: u8) mecha.Parser(void) {
     comptime {
@@ -14,7 +14,7 @@ pub fn char(comptime i: u8) mecha.Parser(void) {
 }
 
 test "char" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     mecha.expectResult(void, .{ .value = {}, .rest = "" }, char('a')(allocator, "a"));
     mecha.expectResult(void, .{ .value = {}, .rest = "a" }, char('a')(allocator, "aa"));
     mecha.expectResult(void, error.ParserFailed, char('a')(allocator, "ba"));
@@ -40,7 +40,7 @@ pub fn range(comptime start: u8, comptime end: u8) mecha.Parser(u8) {
 }
 
 test "range" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     mecha.expectResult(u8, .{ .value = 'a', .rest = "" }, range('a', 'z')(allocator, "a"));
     mecha.expectResult(u8, .{ .value = 'i', .rest = "" }, range('a', 'z')(allocator, "i"));
     mecha.expectResult(u8, .{ .value = 'z', .rest = "" }, range('a', 'z')(allocator, "z"));
@@ -56,7 +56,7 @@ test "range" {
 pub const upper = range('A', 'Z');
 
 test "upper" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -71,7 +71,7 @@ test "upper" {
 pub const lower = range('a', 'z');
 
 test "lower" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -86,7 +86,7 @@ test "lower" {
 pub const alpha = mecha.oneOf(.{ lower, upper });
 
 test "alpha" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -113,7 +113,7 @@ pub fn digit(comptime base: u8) mecha.Parser(u8) {
 }
 
 test "digit" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     i = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
@@ -147,7 +147,7 @@ test "digit" {
 pub const alphanum = mecha.oneOf(.{ alpha, digit(10) });
 
 test "alphanum" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -166,7 +166,7 @@ pub const cntrl = mecha.oneOf(.{
 });
 
 test "cntrl" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -179,7 +179,7 @@ test "cntrl" {
 pub const graph = range(0x21, 0x7e);
 
 test "graph" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -192,7 +192,7 @@ test "graph" {
 pub const print = range(0x20, 0x7e);
 
 test "print" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -208,7 +208,7 @@ pub const space = mecha.oneOf(.{
 });
 
 test "print" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -226,7 +226,7 @@ pub const punct = mecha.oneOf(.{
 });
 
 test "punct" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -260,7 +260,7 @@ pub fn not(comptime parser: anytype) mecha.Parser(u8) {
 }
 
 test "not" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const p = not(alpha);
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -4,7 +4,8 @@ const mecha = @import("../mecha.zig");
 const debug = std.debug;
 const math = std.math;
 const mem = std.mem;
-
+const testing = std.testing;
+///
 /// Constructs a parser that only succeeds if the string starts with `i`.
 pub fn char(comptime i: u8) mecha.Parser(void) {
     comptime {
@@ -13,7 +14,7 @@ pub fn char(comptime i: u8) mecha.Parser(void) {
 }
 
 test "char" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     mecha.expectResult(void, .{ .value = {}, .rest = "" }, char('a')(allocator, "a"));
     mecha.expectResult(void, .{ .value = {}, .rest = "a" }, char('a')(allocator, "aa"));
     mecha.expectResult(void, error.ParserFailed, char('a')(allocator, "ba"));
@@ -39,7 +40,7 @@ pub fn range(comptime start: u8, comptime end: u8) mecha.Parser(u8) {
 }
 
 test "range" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     mecha.expectResult(u8, .{ .value = 'a', .rest = "" }, range('a', 'z')(allocator, "a"));
     mecha.expectResult(u8, .{ .value = 'i', .rest = "" }, range('a', 'z')(allocator, "i"));
     mecha.expectResult(u8, .{ .value = 'z', .rest = "" }, range('a', 'z')(allocator, "z"));
@@ -55,7 +56,7 @@ test "range" {
 pub const upper = range('A', 'Z');
 
 test "upper" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -70,7 +71,7 @@ test "upper" {
 pub const lower = range('a', 'z');
 
 test "lower" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -85,7 +86,7 @@ test "lower" {
 pub const alpha = mecha.oneOf(.{ lower, upper });
 
 test "alpha" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -112,7 +113,7 @@ pub fn digit(comptime base: u8) mecha.Parser(u8) {
 }
 
 test "digit" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     i = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
@@ -146,7 +147,7 @@ test "digit" {
 pub const alphanum = mecha.oneOf(.{ alpha, digit(10) });
 
 test "alphanum" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -165,7 +166,7 @@ pub const cntrl = mecha.oneOf(.{
 });
 
 test "cntrl" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -178,7 +179,7 @@ test "cntrl" {
 pub const graph = range(0x21, 0x7e);
 
 test "graph" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -191,7 +192,7 @@ test "graph" {
 pub const print = range(0x20, 0x7e);
 
 test "print" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -207,7 +208,7 @@ pub const space = mecha.oneOf(.{
 });
 
 test "print" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -225,7 +226,7 @@ pub const punct = mecha.oneOf(.{
 });
 
 test "punct" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
         switch (i) {
@@ -259,7 +260,7 @@ pub fn not(comptime parser: anytype) mecha.Parser(u8) {
 }
 
 test "not" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const p = not(alpha);
     var i: u8 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
@@ -270,8 +271,4 @@ test "not" {
             else => mecha.expectResult(u8, .{ .value = i, .rest = "" }, p(allocator, &[_]u8{i})),
         }
     }
-}
-
-fn failingAllocator() mem.Allocator {
-    return std.testing.FailingAllocator.init(std.testing.allocator, 0).allocator;
 }

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -247,14 +247,13 @@ pub fn not(comptime parser: anytype) mecha.Parser(u8) {
         fn res(allocator: *mem.Allocator, str: []const u8) mecha.Error!Res {
             if (str.len == 0)
                 return error.ParserFailed;
-            if (parser(allocator, str)) |_| {
-                return error.ParserFailed;
-            } else |e| {
-                switch (e) {
-                    error.ParserFailed => return Res.init(str[0], str[1..]),
-                    else => return e,
-                }
-            }
+
+            _ = parser(allocator, str) catch |e| switch (e) {
+                error.ParserFailed => return Res.init(str[0], str[1..]),
+                else => return e,
+            };
+
+            return error.ParserFailed;
         }
     }.res;
 }

--- a/src/utf8.zig
+++ b/src/utf8.zig
@@ -16,7 +16,7 @@ pub fn char(comptime c: u21) mecha.Parser(void) {
 }
 
 test "char" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     mecha.expectResult(void, .{ .value = {}, .rest = "" }, char('a')(allocator, "a"));
     mecha.expectResult(void, .{ .value = {}, .rest = "a" }, char('a')(allocator, "aa"));
     mecha.expectResult(void, error.ParserFailed, char('a')(allocator, "ba"));
@@ -57,7 +57,7 @@ pub fn range(comptime start: u21, comptime end: u21) mecha.Parser(u21) {
 }
 
 test "range" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     mecha.expectResult(u21, .{ .value = 'a', .rest = "" }, range('a', 'z')(allocator, "a"));
     mecha.expectResult(u21, .{ .value = 'c', .rest = "" }, range('a', 'z')(allocator, "c"));
     mecha.expectResult(u21, .{ .value = 'z', .rest = "" }, range('a', 'z')(allocator, "z"));
@@ -97,7 +97,7 @@ pub fn not(comptime parser: anytype) mecha.Parser(u21) {
 }
 
 test "not" {
-    var allocator = testing.failing_allocator;
+    const allocator = testing.failing_allocator;
     const p = not(comptime range('a', 'z'));
     var i: u16 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {

--- a/src/utf8.zig
+++ b/src/utf8.zig
@@ -80,11 +80,9 @@ pub fn not(comptime parser: anytype) mecha.Parser(u21) {
                 return error.ParserFailed;
             if (parser(allocator, str)) |_| {
                 return error.ParserFailed;
-            } else |e| {
-                switch (e) {
-                    error.ParserFailed => {},
-                    else => return e,
-                }
+            } else |e| switch (e) {
+                error.ParserFailed => {},
+                else => return e,
             }
 
             const cp_len = unicode.utf8ByteSequenceLength(str[0]) catch return error.ParserFailed;

--- a/src/utf8.zig
+++ b/src/utf8.zig
@@ -1,8 +1,9 @@
 const std = @import("std");
 const mecha = @import("../mecha.zig");
 
-const mem = std.mem;
 const math = std.math;
+const mem = std.mem;
+const testing = std.testing;
 const unicode = std.unicode;
 
 /// Constructs a parser that only succeeds if the string starts with `c`.
@@ -15,7 +16,7 @@ pub fn char(comptime c: u21) mecha.Parser(void) {
 }
 
 test "char" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     mecha.expectResult(void, .{ .value = {}, .rest = "" }, char('a')(allocator, "a"));
     mecha.expectResult(void, .{ .value = {}, .rest = "a" }, char('a')(allocator, "aa"));
     mecha.expectResult(void, error.ParserFailed, char('a')(allocator, "ba"));
@@ -56,7 +57,7 @@ pub fn range(comptime start: u21, comptime end: u21) mecha.Parser(u21) {
 }
 
 test "range" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     mecha.expectResult(u21, .{ .value = 'a', .rest = "" }, range('a', 'z')(allocator, "a"));
     mecha.expectResult(u21, .{ .value = 'c', .rest = "" }, range('a', 'z')(allocator, "c"));
     mecha.expectResult(u21, .{ .value = 'z', .rest = "" }, range('a', 'z')(allocator, "z"));
@@ -96,7 +97,7 @@ pub fn not(comptime parser: anytype) mecha.Parser(u21) {
 }
 
 test "not" {
-    var allocator = &failingAllocator();
+    var allocator = testing.failing_allocator;
     const p = not(comptime range('a', 'z'));
     var i: u16 = 0;
     while (i <= math.maxInt(u7)) : (i += 1) {
@@ -106,8 +107,4 @@ test "not" {
             else => mecha.expectResult(u21, .{ .value = c, .rest = "" }, p(allocator, &[_]u8{c})),
         }
     }
-}
-
-fn failingAllocator() mem.Allocator {
-    return std.testing.FailingAllocator.init(std.testing.allocator, 0).allocator;
 }


### PR DESCRIPTION
Attempts to address #21 
- Makes all parsers return `mecha.Error!Result` instead of `Result`: 
    ```zig
    Error = error{ParserFailed, OtherError} || mem.Allocator.Error
    ```
  `error.ParserFailed` is treated as `null` was previously. Other errors are simply allowed to bubble up as mecha can't do anything about them.
- All parsers are now of the signature `fn(*mem.Allocator, []const u8) Error!Result(T)`
  - All the old tests were updated to feed the parser a `FailingAllocator` to preserve the information that they shouldn't allocate. 
- Convert now takes a function of type `fn( *mem.Allocator, ParserResult(parser)) !T` if `conv` returns an error in the `mecha.Error` error set it is returned else `error.OtherError` is returned.
  - The built in convert functions all return `error.ParseFailed` on failure to convert as this was the old behavior.   

Making `manyN`, `manyRange`, and `many` allocate the result of what they parse is not addressed.