### PR TITLE
make ascii.char and utf8.char return u8/u21

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ const hex2 = mecha.int(u8, .{
 const rgb1 = mecha.map(Rgb, mecha.toStruct(Rgb), mecha.manyN(hex1, 3, .{}));
 const rgb2 = mecha.map(Rgb, mecha.toStruct(Rgb), mecha.manyN(hex2, 3, .{}));
 const rgb = mecha.combine(.{
-    mecha.ascii.char('#'),
+    mecha.discard(mecha.ascii.char('#')),
     mecha.oneOf(.{
         rgb2,
         rgb1,

--- a/example/json.zig
+++ b/example/json.zig
@@ -57,7 +57,7 @@ const char = mecha.oneOf(.{
     mecha.discard(mecha.utf8.range(0x0020, '"' - 1)),
     mecha.discard(mecha.utf8.range('"' + 1, '\\' - 1)),
     mecha.discard(mecha.utf8.range('\\' + 1, 0x10FFFF)),
-    mecha.combine(.{ mecha.utf8.char('\\'), escape }),
+    mecha.discard(mecha.combine(.{ mecha.discard(mecha.utf8.char('\\')), escape })),
 });
 
 const escape = mecha.oneOf(.{
@@ -81,25 +81,25 @@ const hex = mecha.oneOf(.{
 const integer = mecha.oneOf(.{
     mecha.combine(.{ onenine, digits }),
     jdigit,
-    mecha.combine(.{ mecha.utf8.char('-'), onenine, digits }),
-    mecha.combine(.{ mecha.utf8.char('-'), jdigit }),
+    mecha.combine(.{ mecha.discard(mecha.utf8.char('-')), onenine, digits }),
+    mecha.combine(.{ mecha.discard(mecha.utf8.char('-')), jdigit }),
 });
 
 const digits = mecha.discard(mecha.many(jdigit, .{ .collect = false, .min = 1 }));
 
 const jdigit = mecha.oneOf(.{
-    mecha.utf8.char('0'),
+    mecha.discard(mecha.utf8.char('0')),
     onenine,
 });
 
 const onenine = mecha.discard(mecha.utf8.range('1', '9'));
 
 const fraction = mecha.discard(mecha.opt(
-    mecha.combine(.{ mecha.utf8.char('.'), digits }),
+    mecha.combine(.{ mecha.discard(mecha.utf8.char('.')), digits }),
 ));
 
 const exponent = mecha.discard(mecha.opt(mecha.combine(
-    .{ mecha.oneOf(.{ mecha.utf8.char('E'), mecha.utf8.char('e') }), sign, digits },
+    .{ mecha.discard(mecha.oneOf(.{ mecha.utf8.char('E'), mecha.utf8.char('e') })), sign, digits },
 )));
 
 const sign = mecha.discard(mecha.opt(mecha.oneOf(.{

--- a/example/rgb.zig
+++ b/example/rgb.zig
@@ -24,7 +24,7 @@ const hex2 = mecha.int(u8, .{
 const rgb1 = mecha.map(Rgb, mecha.toStruct(Rgb), mecha.manyN(hex1, 3, .{}));
 const rgb2 = mecha.map(Rgb, mecha.toStruct(Rgb), mecha.manyN(hex2, 3, .{}));
 const rgb = mecha.combine(.{
-    mecha.ascii.char('#'),
+    mecha.discard(mecha.ascii.char('#')),
     mecha.oneOf(.{
         rgb2,
         rgb1,

--- a/src/ascii.zig
+++ b/src/ascii.zig
@@ -30,8 +30,8 @@ pub fn charPred(comptime a: u8) *const fn (u8) bool {
 }
 
 /// Constructs a parser that only succeeds if the string starts with `i`.
-pub fn char(comptime c: u8) mecha.Parser(void) {
-    return mecha.discard(wrap(charPred(c)));
+pub fn char(comptime c: u8) mecha.Parser(u8) {
+    return wrap(charPred(c));
 }
 
 test "char" {

--- a/src/utf8.zig
+++ b/src/utf8.zig
@@ -29,23 +29,23 @@ pub fn wrap(comptime predicate: *const fn (u21) bool) mecha.Parser(u21) {
 }
 
 /// Constructs a parser that only succeeds if the string starts with `c`.
-pub fn char(comptime c: u21) mecha.Parser(void) {
-    comptime {
-        var array: [4]u8 = undefined;
-        const len = unicode.utf8Encode(c, array[0..]) catch unreachable;
-        return mecha.string(array[0..len]);
-    }
+pub fn char(comptime c: u21) mecha.Parser(u21) {
+    return wrap(struct {
+        fn pred(cp: u21) bool {
+            return c == cp;
+        }
+    }.pred);
 }
 
 test "char" {
     const allocator = testing.failing_allocator;
-    try mecha.expectResult(void, .{ .value = {}, .rest = "" }, char('a')(allocator, "a"));
-    try mecha.expectResult(void, .{ .value = {}, .rest = "a" }, char('a')(allocator, "aa"));
-    try mecha.expectResult(void, error.ParserFailed, char('a')(allocator, "ba"));
-    try mecha.expectResult(void, error.ParserFailed, char('a')(allocator, ""));
-    try mecha.expectResult(void, .{ .value = {}, .rest = "ā" }, char(0x100)(allocator, "Āā"));
-    try mecha.expectResult(void, error.ParserFailed, char(0x100)(allocator, ""));
-    try mecha.expectResult(void, error.ParserFailed, char(0x100)(allocator, "\xc0"));
+    try mecha.expectResult(u21, .{ .value = 'a', .rest = "" }, char('a')(allocator, "a"));
+    try mecha.expectResult(u21, .{ .value = 'a', .rest = "a" }, char('a')(allocator, "aa"));
+    try mecha.expectResult(u21, error.ParserFailed, char('a')(allocator, "ba"));
+    try mecha.expectResult(u21, error.ParserFailed, char('a')(allocator, ""));
+    try mecha.expectResult(u21, .{ .value = 'Ā', .rest = "ā" }, char(0x100)(allocator, "Āā"));
+    try mecha.expectResult(u21, error.ParserFailed, char(0x100)(allocator, ""));
+    try mecha.expectResult(u21, error.ParserFailed, char(0x100)(allocator, "\xc0"));
 }
 
 /// Constructs a parser that only succeeds if the string starts with


### PR DESCRIPTION
this makes them consistent with the rest of the parsers in ascii/utf8.

fixes https://github.com/Hejsil/mecha/issues/42