### PR TITLE
Add toUnion converter and basic tests

### DIFF
--- a/mecha.zig
+++ b/mecha.zig
@@ -674,10 +674,10 @@ pub fn toStruct(comptime T: type) ToStructResult(T) {
 
 /// Constructs a conversion function for `map` that initializes a union `T`
 /// with the value passed to it using `@unionInit` with the tag `tag`.
-pub fn unionInit(comptime T: type, comptime tag: @typeInfo(T).@"union".tag.?) ToStructResult(T) {
+pub fn unionInit(comptime T: type, comptime tag: @typeInfo(T).@"union".tag_type.?) ToStructResult(T) {
     return struct {
         fn func(x: anytype) T {
-            return @unionInit(T, @tagName(index), x);
+            return @unionInit(T, @tagName(tag), x);
         }
     }.func;
 }

--- a/mecha.zig
+++ b/mecha.zig
@@ -672,10 +672,9 @@ pub fn toStruct(comptime T: type) ToStructResult(T) {
     }.func;
 }
 
-/// Constructs a conversion function for `map` that, given a union type `T`
-/// indexed by an enum as well as an instance of that enum, will create an
-/// instance of `T` with the value being mapped over at `index`.
-pub fn unionInit(comptime T: type, comptime index: anytype) ToStructResult(T) {
+/// Constructs a conversion function for `map` that initializes a union `T`
+/// with the value passed to it using `@unionInit` with the tag `tag`.
+pub fn unionInit(comptime T: type, comptime tag: @typeInfo(T).@"union".tag.?) ToStructResult(T) {
     return struct {
         fn func(x: anytype) T {
             return @unionInit(T, @tagName(index), x);

--- a/mecha.zig
+++ b/mecha.zig
@@ -682,22 +682,6 @@ pub fn unionInit(comptime T: type, comptime tag: @typeInfo(T).@"union".tag_type.
     }.func;
 }
 
-/// Gets the type of a sub-struct of a tagged union at a given enum index.
-/// This function is useful for tagged unions with anonymous sub-structs.
-pub fn unionSubtype(comptime T: type, comptime index: anytype) type {
-    const info = @typeInfo(T);
-    const union_fields = info.@"union".fields;
-    const enum_name = @tagName(index);
-
-    inline for (union_fields) |field| {
-        if (comptime std.mem.eql(u8, field.name, enum_name)) {
-            return field.type;
-        }
-    }
-
-    @compileError("Failed to find enum in union type");
-}
-
 test "map" {
     const allocator = testing.failing_allocator;
     const Point = struct {
@@ -708,11 +692,11 @@ test "map" {
         point,
         person,
     };
-    const Message = union(MessageType) { point: Point, person: struct {
+    const Person = struct {
         name: []const u8,
         age: u32,
-    } };
-    const Person = unionSubtype(Message, MessageType.person);
+    };
+    const Message = union(MessageType) { point: Point, person: Person };
     const parser1 = comptime combine(.{
         int(usize, .{}),
         ascii.char(' ').discard(),


### PR DESCRIPTION
Closes #63.

Implements `toUnion`, a converter for use in `map` that will map to a substruct of a tagged union with the type of the union and an enum index into it.