### PR TITLE
Add parser position and "token span" tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,26 +38,26 @@ const rgb = mecha.combine(.{
 test "rgb" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const a = (try rgb.parse(allocator, "#aabbcc")).value;
+    var ctx = mecha.Context{};
+    const a = (try rgb.parse(allocator, &ctx, "#aabbcc")).value;
     try testing.expectEqual(@as(u8, 0xaa), a.r);
     try testing.expectEqual(@as(u8, 0xbb), a.g);
     try testing.expectEqual(@as(u8, 0xcc), a.b);
 
-    const b = (try rgb.parse(allocator, "#abc")).value;
+    const b = (try rgb.parse(allocator, &ctx, "#abc")).value;
     try testing.expectEqual(@as(u8, 0xaa), b.r);
     try testing.expectEqual(@as(u8, 0xbb), b.g);
     try testing.expectEqual(@as(u8, 0xcc), b.b);
 
-    const c = (try rgb.parse(allocator, "#000000")).value;
+    const c = (try rgb.parse(allocator, &ctx, "#000000")).value;
     try testing.expectEqual(@as(u8, 0), c.r);
     try testing.expectEqual(@as(u8, 0), c.g);
     try testing.expectEqual(@as(u8, 0), c.b);
 
-    const d = (try rgb.parse(allocator, "#000")).value;
+    const d = (try rgb.parse(allocator, &ctx, "#000")).value;
     try testing.expectEqual(@as(u8, 0), d.r);
     try testing.expectEqual(@as(u8, 0), d.g);
     try testing.expectEqual(@as(u8, 0), d.b);
 }
 
 ```
-

--- a/example/json.zig
+++ b/example/json.zig
@@ -124,21 +124,25 @@ const ws = mecha.oneOf(.{
 }).many(.{ .collect = false }).discard();
 
 fn ok(s: []const u8) !void {
-    const res = json.parse(testing.allocator, s) catch @panic("test failure");
+    var ctx = mecha.Context{};
+    const res = json.parse(testing.allocator, &ctx, s) catch @panic("test failure");
     try testing.expectEqualStrings("", res.rest);
 }
 
 fn err(s: []const u8) !void {
-    try testing.expectError(error.ParserFailed, json.parse(testing.allocator, s));
+    var ctx = mecha.Context{};
+    try testing.expectError(error.ParserFailed, json.parse(testing.allocator, &ctx, s));
 }
 
 fn errNotAllParsed(s: []const u8) !void {
-    const res = json.parse(testing.allocator, s) catch @panic("test failure");
+    var ctx = mecha.Context{};
+    const res = json.parse(testing.allocator, &ctx, s) catch @panic("test failure");
     try testing.expect(res.rest.len != 0);
 }
 
 fn any(s: []const u8) void {
-    _ = json.parse(testing.allocator, s) catch {};
+    var ctx = mecha.Context{};
+    _ = json.parse(testing.allocator, &ctx, s) catch {};
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/example/rgb.zig
+++ b/example/rgb.zig
@@ -31,22 +31,23 @@ const rgb = mecha.combine(.{
 test "rgb" {
     const testing = std.testing;
     const allocator = testing.allocator;
-    const a = (try rgb.parse(allocator, "#aabbcc")).value;
+    var ctx = mecha.Context{};
+    const a = (try rgb.parse(allocator, &ctx, "#aabbcc")).value;
     try testing.expectEqual(@as(u8, 0xaa), a.r);
     try testing.expectEqual(@as(u8, 0xbb), a.g);
     try testing.expectEqual(@as(u8, 0xcc), a.b);
 
-    const b = (try rgb.parse(allocator, "#abc")).value;
+    const b = (try rgb.parse(allocator, &ctx, "#abc")).value;
     try testing.expectEqual(@as(u8, 0xaa), b.r);
     try testing.expectEqual(@as(u8, 0xbb), b.g);
     try testing.expectEqual(@as(u8, 0xcc), b.b);
 
-    const c = (try rgb.parse(allocator, "#000000")).value;
+    const c = (try rgb.parse(allocator, &ctx, "#000000")).value;
     try testing.expectEqual(@as(u8, 0), c.r);
     try testing.expectEqual(@as(u8, 0), c.g);
     try testing.expectEqual(@as(u8, 0), c.b);
 
-    const d = (try rgb.parse(allocator, "#000")).value;
+    const d = (try rgb.parse(allocator, &ctx, "#000")).value;
     try testing.expectEqual(@as(u8, 0), d.r);
     try testing.expectEqual(@as(u8, 0), d.g);
     try testing.expectEqual(@as(u8, 0), d.b);

--- a/mecha.zig
+++ b/mecha.zig
@@ -30,6 +30,24 @@ pub fn Parser(comptime _T: type) type {
         pub const mapConst = mecha.mapConst;
         pub const map = mecha.map;
         pub const opt = mecha.opt;
+
+        const Self = @This();
+
+        fn report(allocator: mem.Allocator, str: []const u8) Error!Result(T) {
+            var ctx = mecha.Context{};
+            Self.parse(allocator, &ctx, str) catch |e| {
+                if (e == error.ParserFailed) {
+                    std.debug.print("Parser {s} ({s}:{d}:{d}) failed at position {d}", .{
+                        ctx.loc.fn_name,
+                        ctx.loc.file,
+                        ctx.loc.line,
+                        ctx.loc.column,
+                        ctx.pos,
+                    });
+                    return e;
+                }
+            };
+        }
     };
 }
 


### PR DESCRIPTION
Report location (both input and Zig code) of a failed parse, as well as the span of each successful parse.