### PR TITLE
add peek functionality?

### DIFF
--- a/mecha.zig
+++ b/mecha.zig
@@ -30,6 +30,7 @@ pub fn Parser(comptime _T: type) type {
         pub const mapConst = mecha.mapConst;
         pub const map = mecha.map;
         pub const opt = mecha.opt;
+        pub const peek = mecha.peek;
     };
 }
 
@@ -359,6 +360,27 @@ test "opt" {
     try expectOk(?u8, 1, 'a', try p1.parse(fa, "a"));
     try expectOk(?u8, 1, 'a', try p1.parse(fa, "aa"));
     try expectOk(?u8, 0, null, try p1.parse(fa, "1"));
+}
+
+pub fn peek(comptime parser: anytype) mecha.Parser(void) {
+    const Res = mecha.Result(void);
+    return .{ .parse = struct {
+        fn parse(allocator: mem.Allocator, str: []const u8) mecha.Error!Res {
+            const res = try parser.parse(allocator, str);
+            return switch (res.value) {
+                .ok => Res.ok(0, {}),
+                .err => Res.err(0),
+            };
+        }
+    }.parse };
+}
+
+test "peek" {
+    const fa = testing.failing_allocator;
+    const p1 = comptime ascii.range('a', 'z').peek();
+    try expectOk(void, 0, {}, try p1.parse(fa, "a"));
+    try expectOk(void, 0, {}, try p1.parse(fa, "aa"));
+    try expectErr(void, 0, try p1.parse(fa, "1"));
 }
 
 fn parsersTypes(comptime parsers: anytype) []const type {


### PR DESCRIPTION
Greetings - and thank you for this awesome module!  Amazing demonstration of the power of Zig comptime!

I built a "peek" parser that does not consume anything, but checks to see if the nested parser parsed.  It returns .ok if the nested parser parses with an index = 0.  If the nested parser fails it returns .err with index = 0.

This was useful for parsing an identifier where I needed the first character to be alphabetic and the following characters could be alphanumeric.  When I initially built this pattern, using a combine, the resulting type was a {u8, []u8} and required additional handling (e.g. didn't play well with other branches of a oneOf as the other branch returned []u8.  Using peek inside the combine I was able to insist on the first character being alpha and yet still easily generate a []u8 return type.

Seems like this could be useful in other circumstances...?