### PR TITLE
Convert ArrayList to ArrayListUnmanaged

### DIFF
--- a/mecha.zig
+++ b/mecha.zig
@@ -241,9 +241,9 @@ pub fn many(comptime parser: anytype, comptime options: ManyOptions) Parser(Many
     return .{ .parse = struct {
         fn parse(allocator: mem.Allocator, str: []const u8) Error!Res {
             var res = if (options.collect)
-                try std.ArrayList(Element).initCapacity(allocator, options.min)
+                try std.ArrayListUnmanaged(Element).initCapacity(allocator, options.min)
             else {};
-            errdefer if (options.collect) res.deinit();
+            errdefer if (options.collect) res.deinit(allocator);
 
             var index: usize = 0;
             var i: usize = 0;
@@ -265,7 +265,7 @@ pub fn many(comptime parser: anytype, comptime options: ManyOptions) Parser(Many
                 switch (r.value) {
                     .ok => |value| {
                         if (options.collect)
-                            try res.append(value);
+                            try res.append(allocator, value);
                     },
                     .err => break,
                 }
@@ -277,7 +277,7 @@ pub fn many(comptime parser: anytype, comptime options: ManyOptions) Parser(Many
                 return Res.err(index);
 
             const value = if (options.collect)
-                try res.toOwnedSlice()
+                try res.toOwnedSlice(allocator)
             else
                 str[0..index];
 


### PR DESCRIPTION
Zig is no longer supporting `ArrayList`s with a field containing an allocator. Instead, the developer must pass an allocator to each method call that may allocate, deallocate, or reallocate. In order to maintain compatibility with slightly older versions of zig, instead of just using the new definition of `ArrayList`, using `ArrayListUnmanaged` will work regardless of what version of zig one is using. At some point, zig may remove the `ArrayListUnmanaged` function altogether, at which point we should simply replace `ArrayListUnmanaged` with `ArrayList` in `mecha.zig`